### PR TITLE
Filter processing jobs by user ID

### DIFF
--- a/src/pages/private/Documents.tsx
+++ b/src/pages/private/Documents.tsx
@@ -50,15 +50,18 @@ export default function Documents() {
   // Processing jobs state
   const [activeJobs, setActiveJobs] = useState<ProcessingJobStatus[]>([]);
   const [failedJobs, setFailedJobs] = useState<ProcessingJobStatus[]>([]);
-  const [dismissedFailedJobIds, setDismissedFailedJobIds] = useState<Set<string>>(() => {
+  const readDismissedFailedJobIds = (): Set<string> => {
+    if (typeof window === "undefined") return new Set();
     try {
-      const raw = localStorage.getItem("dismissed_failed_processing_job_ids");
+      const raw = window.localStorage?.getItem("dismissed_failed_processing_job_ids");
       const parsed = raw ? (JSON.parse(raw) as string[]) : [];
       return new Set(parsed);
     } catch {
       return new Set();
     }
-  });
+  };
+
+  const [, setDismissedFailedJobIds] = useState<Set<string>>(() => readDismissedFailedJobIds());
 
   // PDF viewer state
   const [showPdfViewer, setShowPdfViewer] = useState<boolean>(false);
@@ -96,12 +99,13 @@ export default function Documents() {
     if (!session) return;
 
     const loadJobs = async () => {
+      const dismissed = readDismissedFailedJobIds();
       const [jobs, failed] = await Promise.all([
-        getActiveProcessingJobs(),
-        getRecentFailedProcessingJobs(10),
+        getActiveProcessingJobs(session.user.id),
+        getRecentFailedProcessingJobs(session.user.id, 10),
       ]);
       setActiveJobs(jobs);
-      setFailedJobs(failed.filter((j) => !dismissedFailedJobIds.has(j.id)));
+      setFailedJobs(failed.filter((j) => !dismissed.has(j.id)));
     };
 
     // Load immediately
@@ -115,11 +119,12 @@ export default function Documents() {
     }, 3000);
 
     return () => clearInterval(interval);
-  }, [session, dismissedFailedJobIds]);
+  }, [session]);
 
   const persistDismissedFailedJobs = (ids: Set<string>) => {
+    if (typeof window === "undefined") return;
     try {
-      localStorage.setItem(
+      window.localStorage?.setItem(
         "dismissed_failed_processing_job_ids",
         JSON.stringify(Array.from(ids))
       );

--- a/src/supabase/documents.ts
+++ b/src/supabase/documents.ts
@@ -207,10 +207,11 @@ export async function getProcessingStatus(
 }
 
 // Get all active processing jobs for current user
-export async function getActiveProcessingJobs(): Promise<ProcessingJobStatus[]> {
+export async function getActiveProcessingJobs(userId: string): Promise<ProcessingJobStatus[]> {
   const { data, error } = await supabase
     .from("processing_jobs")
     .select("*")
+    .eq("user_id", userId)
     .in("status", ["pending", "parsing", "extracting_metadata", "uploading", "sectioning", "chunking", "embedding", "saving"])
     .order("created_at", { ascending: false });
 
@@ -223,10 +224,11 @@ export async function getActiveProcessingJobs(): Promise<ProcessingJobStatus[]> 
 }
 
 // Get recent failed processing jobs for current user
-export async function getRecentFailedProcessingJobs(limit = 10): Promise<ProcessingJobStatus[]> {
+export async function getRecentFailedProcessingJobs(userId: string, limit = 10): Promise<ProcessingJobStatus[]> {
   const { data, error } = await supabase
     .from("processing_jobs")
     .select("*")
+    .eq("user_id", userId)
     .eq("status", "failed")
     .order("created_at", { ascending: false })
     .limit(limit);


### PR DESCRIPTION
Updated getActiveProcessingJobs and getRecentFailedProcessingJobs to require a userId parameter and filter jobs by user. Adjusted Documents page to pass session user ID to these functions and improved handling of dismissed failed job IDs for better SSR compatibility.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Scopes job queries and dismissed-failure persistence to the current user and updates Documents page to use user-scoped APIs with SSR-safe localStorage access.
> 
> - **Documents UI (`src/pages/private/Documents.tsx`)**:
>   - Pass `session.user.id` to `getActiveProcessingJobs` and `getRecentFailedProcessingJobs` and poll accordingly.
>   - Persist dismissed failed job IDs per-user via `localStorage` key `dismissed_failed_processing_job_ids:{userId}` with SSR guards; update dismiss single/all handlers to use user-scoped storage.
>   - Simplify dismissed state handling; remove it from effect deps to avoid unnecessary reloads.
> - **Supabase queries (`src/supabase/documents.ts`)**:
>   - Change `getActiveProcessingJobs(userId)` and `getRecentFailedProcessingJobs(userId, limit)` to require `userId` and filter with `.eq("user_id", userId)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 148cad03dfbe24603236f99baeffbc17022d9d68. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Per-user, SSR-safe handling of dismissed failed jobs so dismissed state persists correctly and is isolated per account.
  * Improved resilience when loading job data (graceful empty results on query errors).

* **New Features**
  * Job queries now return results scoped to the current user.
  * Job status now surfaces error codes and retry count for clearer failure diagnostics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->